### PR TITLE
Dev expand notif table

### DIFF
--- a/backend/app/models/notification.ts
+++ b/backend/app/models/notification.ts
@@ -24,10 +24,16 @@ export default class Notification extends BaseModel {
   declare shouldBeDisplayed: boolean;
 
   @column()
-  declare notificationTypeId: number;
+  declare notificationTypeId: number; // references notification_type.id
 
   @belongsTo(() => NotificationType)
   declare notificationType: BelongsTo<typeof NotificationType>;
+
+  @column()
+  declare startedAt: DateTime;
+
+  @column()
+  declare finishedAt: DateTime;
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime;

--- a/backend/database/migrations/1738130250624_create_notifications_table.ts
+++ b/backend/database/migrations/1738130250624_create_notifications_table.ts
@@ -10,7 +10,13 @@ export default class extends BaseSchema {
       table.string("summary").notNullable();
       table.string("message").nullable();
 
-      table.integer("archive_id").unsigned().notNullable().references("id").inTable("archives").onDelete("RESTRICT");
+      table
+        .integer("archive_id") //
+        .unsigned()
+        .notNullable()
+        .references("id")
+        .inTable("archives")
+        .onDelete("RESTRICT");
 
       table.boolean("should_be_displayed").notNullable();
 
@@ -21,6 +27,9 @@ export default class extends BaseSchema {
         .references("id")
         .inTable("notification_types")
         .onDelete("RESTRICT");
+
+      table.timestamp("started_at").notNullable();
+      table.timestamp("finished_at"); // should this be nullable?
 
       table.timestamp("created_at").notNullable();
       table.timestamp("updated_at").notNullable();

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -16,7 +16,7 @@ transmit.registerRoutes();
 
 router.get("/sse", async () => {
   transmit.broadcast("global", { message: "hello" });
-  return { hello: "Ankita" };
+  return { hello: "world" };
 });
 
 // auth


### PR DESCRIPTION
- Notification table had an issue where it was difficult to understand how recurring notifications would be handled.
- We do not want 100s of entries in the notification table for the same recurring anomaly.
- Hence we can add two columns that can track at which point in time, the anomaly started and another column that can track when the anomaly ended.
- This way all recurring anomalous notifications will be consolidated in one single row inside of the notification table.
- This PR adds changes to the Notification Model and its Migrations to accomplish this.
- APIs regarding this will be added in future development.
- The `finished_at` column is nullable for now, which seems correct for now.
 